### PR TITLE
Master

### DIFF
--- a/.github/workflows/close_invalid_prs.yml
+++ b/.github/workflows/close_invalid_prs.yml
@@ -1,0 +1,34 @@
+name: Close Invalid Pull Requests
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+  workflow_dispatch:
+
+jobs:
+  close_invalid_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Get Default Branch
+        id: get-default-branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --template '{{.defaultBranchRef.name}}')
+          echo "default_branch=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Close PRs from Default Branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEFAULT_BRANCH=${{ steps.get-default-branch.outputs.default_branch }}
+          PR_NUMBERS=$(gh pr list --state open --json number,headRefName --template '{{range .}}{{if eq .headRefName "'"$DEFAULT_BRANCH"'"}}{{.number}} {{end}}{{end}}')
+
+          for PR_NUMBER in $PR_NUMBERS; do
+            echo "Closing PR #$PR_NUMBER from default branch '$DEFAULT_BRANCH'."
+            gh pr close $PR_NUMBER --comment "This pull request is invalid because it's created from the default branch '$DEFAULT_BRANCH'. Please use a feature branch."
+          done
+        shell: bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import dev.slne.surf.surfapi.gradle.util.slneReleases
+
 buildscript {
     repositories {
         gradlePluginPortal()
@@ -12,4 +14,12 @@ buildscript {
 allprojects {
     group = "dev.slne.surf"
     version = findProperty("version") as String
+
+    afterEvaluate {
+        configure<PublishingExtension> {
+            repositories {
+                slneReleases()
+            }
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,9 @@ buildscript {
 allprojects {
     group = "dev.slne.surf"
     version = findProperty("version") as String
+}
 
+subprojects {
     afterEvaluate {
         configure<PublishingExtension> {
             repositories {


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically close invalid pull requests. The workflow is designed to identify and close pull requests that are created from the default branch, ensuring that contributors use feature branches for their work.

Key changes:

* [`.github/workflows/close_invalid_prs.yml`](diffhunk://#diff-c970419bc10159e2721f355c3f99540c11ccda51d8b33a4b1f779f872cb2243dR1-R34): Added a new workflow named "Close Invalid Pull Requests" that triggers on pull request events (opened, reopened, synchronize) and manual dispatch. The workflow includes steps to check out the repository, determine the default branch, and close any open pull requests originating from the default branch with a comment explaining the reason.