### PR TITLE
Add BALANCE_OTHER permission for viewing player balances

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=4.0.1
+version=4.0.2
 org.gradle.jvmargs=-Xmx4G

--- a/surf-transaction-api/api/surf-transaction-api.api
+++ b/surf-transaction-api/api/surf-transaction-api.api
@@ -129,6 +129,7 @@ public final class dev/slne/surf/transaction/api/currency/Currency$DefaultImpls 
 }
 
 public abstract class dev/slne/surf/transaction/api/currency/CurrencyScale : java/lang/Enum {
+	public static final field Companion Ldev/slne/surf/transaction/api/currency/CurrencyScale$Companion;
 	public static final field DECIMAL_2 Ldev/slne/surf/transaction/api/currency/CurrencyScale;
 	public static final field INTEGER Ldev/slne/surf/transaction/api/currency/CurrencyScale;
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -138,6 +139,11 @@ public abstract class dev/slne/surf/transaction/api/currency/CurrencyScale : jav
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Ldev/slne/surf/transaction/api/currency/CurrencyScale;
 	public static fun values ()[Ldev/slne/surf/transaction/api/currency/CurrencyScale;
+}
+
+public final class dev/slne/surf/transaction/api/currency/CurrencyScale$Companion {
+	public final fun getMAX_VALUE ()Ljava/math/BigDecimal;
+	public final fun maxValue (Ldev/slne/surf/transaction/api/currency/CurrencyScale;)Ljava/math/BigDecimal;
 }
 
 public final class dev/slne/surf/transaction/api/currency/CurrencyService$Companion : dev/slne/surf/transaction/api/currency/CurrencyService {

--- a/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/CommandPermission.kt
+++ b/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/CommandPermission.kt
@@ -7,6 +7,7 @@ object CommandPermission : PermissionRegistry() {
     private const val PREFIX = "surf.transaction.command"
 
     val BALANCE = create("$PREFIX.balance")
+    val BALANCE_OTHER = create("$BALANCE.other")
 
     val CURRENCY = create("$PREFIX.currency")
     val CURRENCY_ADMIN = create("$CURRENCY.admin")

--- a/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/balance/BalanceCommand.kt
+++ b/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/balance/BalanceCommand.kt
@@ -31,6 +31,8 @@ fun balanceCommand() = commandTree("balance") {
         }
 
         argument(AsyncPlayerProfileArgument("player")) {
+            withPermission(CommandPermission.BALANCE_OTHER)
+
             anyExecutorSuspend { sender, args ->
                 balance(
                     sender,


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the currency and permissions system, as well as a version bump. The main changes include new permission granularity for balance commands, API extensions for currency scaling, and a patch-level version update.

**Permissions and Command Improvements:**
- Added a new `BALANCE_OTHER` permission in `CommandPermission.kt` to allow more granular control over who can check other players' balances.
- Updated the `balanceCommand` to require the new `BALANCE_OTHER` permission when querying another player's balance.

**Currency API Enhancements:**
- Introduced a `Companion` object to the `CurrencyScale` class, exposing new methods: `getMAX_VALUE()` and `maxValue(CurrencyScale)`, which provide maximum value information for different currency scales. [[1]](diffhunk://#diff-b074e522a6db5670dab0af262f54fd8f563e07b042fc1c5b513cd9ad25f50ca6R132) [[2]](diffhunk://#diff-b074e522a6db5670dab0af262f54fd8f563e07b042fc1c5b513cd9ad25f50ca6R144-R148)

**Versioning:**
- Bumped the project version from `4.0.1` to `4.0.2` in `gradle.properties`.