### PR TITLE
Fix currency initialization issues and remove unused imports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=4.0.2
+version=4.0.3
 org.gradle.jvmargs=-Xmx4G

--- a/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/pay/PayCommand.kt
+++ b/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/pay/PayCommand.kt
@@ -11,6 +11,7 @@ import dev.slne.surf.api.paper.command.executors.playerExecutorSuspend
 import dev.slne.surf.api.paper.command.util.awaitAsyncPlayerProfile
 import dev.slne.surf.api.paper.command.util.idOrThrow
 import dev.slne.surf.transaction.api.currency.Currency
+import dev.slne.surf.transaction.api.currency.CurrencyScale
 import dev.slne.surf.transaction.api.currency.CurrencyScale.Companion.maxValue
 import dev.slne.surf.transaction.api.transaction.TransactionResult
 import dev.slne.surf.transaction.api.user.TransactionUser
@@ -30,7 +31,7 @@ fun payCommand() = commandTree("pay") {
     withAliases("bezahlen", "überweisen")
 
     argument(AsyncPlayerProfileArgument("receiver")) {
-        doubleArgument("amount", min = 1.0, max = Currency.default().scale.maxValue().toDouble()) {
+        doubleArgument("amount", min = 1.0, max = 9_999_999.0) {
             playerExecutorSuspend { sender, args ->
                 pay(
                     sender,

--- a/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/pay/PayCommand.kt
+++ b/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/pay/PayCommand.kt
@@ -11,8 +11,6 @@ import dev.slne.surf.api.paper.command.executors.playerExecutorSuspend
 import dev.slne.surf.api.paper.command.util.awaitAsyncPlayerProfile
 import dev.slne.surf.api.paper.command.util.idOrThrow
 import dev.slne.surf.transaction.api.currency.Currency
-import dev.slne.surf.transaction.api.currency.CurrencyScale
-import dev.slne.surf.transaction.api.currency.CurrencyScale.Companion.maxValue
 import dev.slne.surf.transaction.api.transaction.TransactionResult
 import dev.slne.surf.transaction.api.user.TransactionUser
 import dev.slne.surf.transaction.api.user.transactionUser


### PR DESCRIPTION
This pull request includes a version bump for the project and an update to the pay command argument validation. The most important changes are summarized below:

**Project Version Update:**
* Bumped the project version in `gradle.properties` from `4.0.2` to `4.0.3`.

**Pay Command Argument Validation:**
* Changed the maximum allowed value for the `amount` argument in the `pay` command from `Currency.default().scale.maxValue().toDouble()` to a fixed value of `9_999_999.0` in `PayCommand.kt`, simplifying and making the upper limit explicit.
* Removed the unused import of `CurrencyScale.Companion.maxValue` from `PayCommand.kt`.