### PR TITLE
Fix positive repayments for negative balances

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=4.0.3
+version=4.0.4
 org.gradle.jvmargs=-Xmx4G

--- a/surf-transaction-microservice/src/main/kotlin/dev/slne/surf/transaction/microservice/db/transaction/TransactionRepositoryImpl.kt
+++ b/surf-transaction-microservice/src/main/kotlin/dev/slne/surf/transaction/microservice/db/transaction/TransactionRepositoryImpl.kt
@@ -68,8 +68,9 @@ class TransactionRepositoryImpl : TransactionRepository {
 
         val transactionId = insertedTransactionRow[TransactionTable.id].value
         val insertedReceiverId = insertedTransactionRow[TransactionTable.receiver]?.value
+        val reducesReceiverBalance = transaction.amount < BigDecimal.ZERO
 
-        if (insertedReceiverId != null && !transaction.ignoreMinimumAmount) {
+        if (insertedReceiverId != null && !transaction.ignoreMinimumAmount && reducesReceiverBalance) {
             val balanceAfterTransaction = balanceDecimal0 {
                 (TransactionTable.currency eq currencyId.value) and
                         (TransactionTable.receiver eq insertedReceiverId)


### PR DESCRIPTION
Closes #18

## Summary
- only enforce the minimum-balance validation when a transaction reduces the receiver account balance
- allow positive transactions to accounts that are still below the currency minimum after the transaction
- keep negative balance-reducing transactions blocked so players cannot go further into debt

## Validation
- Reviewed the existing transaction persistence flow: failed persistence rolls back, and transfer sender failures are still mapped from `ReceiverInsufficientFunds` to `SenderInsufficientFunds`.
- Manually checked use cases:
  - player with a negative balance receives money but remains negative: allowed
  - player with a negative balance receives enough money to become non-negative: allowed
  - player tries to send/pay money while that would put or keep their own account below the minimum: blocked as sender insufficient funds
  - direct negative transaction that would further reduce an account below minimum: blocked
  - receiver side of a normal transfer is positive: allowed, including when repaying debt

## Notes
- I could not run the Gradle test suite locally in this environment because the container has no network access to clone/resolve the repository, so the validation above is based on code inspection and branch diff review.