### PR TITLE
Fix currency formatting locale and clean up money transfer command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=4.0.4
+version=4.0.5
 org.gradle.jvmargs=-Xmx4G

--- a/surf-transaction-api/src/main/kotlin/dev/slne/surf/transaction/api/currency/CurrencyScale.kt
+++ b/surf-transaction-api/src/main/kotlin/dev/slne/surf/transaction/api/currency/CurrencyScale.kt
@@ -58,7 +58,7 @@ enum class CurrencyScale {
      */
     fun formatString(
         amount: BigDecimal,
-        locale: Locale = Locale.getDefault(Locale.Category.FORMAT)
+        locale: Locale = Locale.GERMAN
     ): String = NumberFormat.getNumberInstance(locale).format(format(amount))
 
     companion object {

--- a/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/pay/PayCommand.kt
+++ b/surf-transaction-paper/src/main/kotlin/dev/slne/surf/transaction/paper/commands/pay/PayCommand.kt
@@ -50,11 +50,6 @@ private suspend fun pay(
         throw CommandAPI.failWithString("Du kannst dir kein Geld selbst überweisen!")
     }
 
-    sender.sendText {
-        appendInfoPrefix()
-        info("Überweisung wird ausgeführt...")
-    }
-
     val currency = Currency.default()
 
     val receiverName = Components.usernameOrUuid(receiverUuid)


### PR DESCRIPTION
This pull request includes several small changes focused on improving currency formatting, updating the project version, and cleaning up user messaging in the payment command.

Currency formatting:

* The default locale for formatting currency strings in `CurrencyScale.formatString` was changed from the system default to `Locale.GERMAN`, ensuring consistent formatting regardless of server settings.

Project configuration:

* The project version in `gradle.properties` was bumped from `4.0.4` to `4.0.5`.

User messaging:

* The informational message "Überweisung wird ausgeführt..." sent to the sender before processing a payment was removed from `PayCommand.kt`, reducing unnecessary output.